### PR TITLE
Combining local and db carts on login

### DIFF
--- a/client/components/SingleProduct.js
+++ b/client/components/SingleProduct.js
@@ -42,7 +42,12 @@ export class SingleProduct extends React.Component {
     const {quantity} = this.state
     const userId = user.id
     const savedPrice = product.price
-    await this.props.orderProduct({product, userId, quantity, savedPrice})
+    await this.props.orderProduct({
+      product,
+      userId,
+      quantity: Number(quantity),
+      savedPrice: Number(savedPrice)
+    })
     // Redirect to cart
     this.props.history.push('/cart')
   }

--- a/client/components/SingleProduct.js
+++ b/client/components/SingleProduct.js
@@ -41,6 +41,7 @@ export class SingleProduct extends React.Component {
     const {product, user} = this.props
     const {quantity} = this.state
     const userId = user.id
+    console.log('User Id in handleSubmit')
     const savedPrice = product.price
     await this.props.orderProduct({
       product,

--- a/client/components/auth-form.js
+++ b/client/components/auth-form.js
@@ -7,11 +7,11 @@ import {auth} from '../store'
  * COMPONENT
  */
 const AuthForm = props => {
-  const {name, displayName, handleSubmit, error} = props
+  const {name, displayName, handleSubmit, error, cart} = props
 
   return (
     <div>
-      <form onSubmit={handleSubmit} name={name}>
+      <form onSubmit={event => handleSubmit(event, cart)} name={name}>
         <div>
           <label htmlFor="email">
             <small>Email</small>
@@ -45,6 +45,7 @@ const mapLogin = state => {
   return {
     name: 'login',
     displayName: 'Login',
+    cart: state.cart,
     error: state.user.error
   }
 }
@@ -53,18 +54,19 @@ const mapSignup = state => {
   return {
     name: 'signup',
     displayName: 'Sign Up',
+    cart: state.cart,
     error: state.user.error
   }
 }
 
 const mapDispatch = dispatch => {
   return {
-    handleSubmit(evt) {
+    handleSubmit(evt, cart) {
       evt.preventDefault()
       const formName = evt.target.name
       const email = evt.target.email.value
       const password = evt.target.password.value
-      dispatch(auth(email, password, formName))
+      dispatch(auth(email, password, formName, cart))
     }
   }
 }

--- a/client/store/cart.js
+++ b/client/store/cart.js
@@ -21,14 +21,9 @@ export const loadCart = userId => {
       }
     }
   } else {
-    console.log('loadCart thunk triggered without userId on state')
-    // We have a guest user
     // if there's a cart, load it from window.localStorage.cart
     // if there isn't, set it as an empty array
-    // dispatch getCart with that data
     const cart = JSON.parse(window.localStorage.getItem('cart'))
-    // We will optionally return an empty array here, but in the future we will create the cart array in local storage when the user adds their first item
-
     return dispatch => dispatch(getCart(cart || []))
   }
 }

--- a/server/api/orders.js
+++ b/server/api/orders.js
@@ -46,7 +46,7 @@ router.post('/', async (req, res, next) => {
         productId,
         orderId
       },
-      defualts: req.body
+      defaults: req.body
     })
 
     if (!wasCreated) {


### PR DESCRIPTION
Edited user redux auth thunk to grab the localStorage cart, and add it to the user's cart when they log in.

// About the combineLocalCart helper function:
// Intended to take the cart a guest creates, saved on localStorage and Redux, and add those items to the database when that guest logs in or signs up, and localStorage is cleared
// It appears to work well when an existing user logs in
// There is a bug where if the user signs up, only the first item is added. localStorage is cleared
// There is a bigger bug with Google OAuth users, where the localCart seems to persist, and if they don't have a database order it will show up in their cart, but nothing gets updated in the database.

